### PR TITLE
Fix database memory leak/issue (Guild)

### DIFF
--- a/src/Core/Models/GuildConfig.js
+++ b/src/Core/Models/GuildConfig.js
@@ -222,11 +222,8 @@ class GuildConfig {
         const update = {};
         for (const key in guildConfig) {
             this[key] = guildConfig[key];
-            try {
-                JSON.stringify(this[key] );
+            if (!key.startsWith('_') ) {
                 update[key] = guildConfig[key];
-            } catch (e) {
-                // There is nothing we can do here
             }
         }
         this.updatedAt = new Date();

--- a/src/Core/Models/GuildConfig.js
+++ b/src/Core/Models/GuildConfig.js
@@ -219,19 +219,18 @@ class GuildConfig {
         if (guildConfig.guildID !== this.guildID) {
             return Promise.resolve(null);
         }
+        const update = {};
         for (const key in guildConfig) {
             this[key] = guildConfig[key];
-        }
-        this.updatedAt = new Date();
-        const update = {};
-        for (const [key, value] of Object.entries(this) ) {
             try {
-                JSON.stringify(value);
-                update[key] = value;
+                JSON.stringify(this[key] );
+                update[key] = guildConfig[key];
             } catch (e) {
                 // There is nothing we can do here
             }
         }
+        this.updatedAt = new Date();
+        update.updatedAt = new Date();
 
         const newConf = await this._axon.DBProvider.saveGuild(this.guildID, update);
         return newConf ? this : null;

--- a/src/Core/Models/GuildConfig.js
+++ b/src/Core/Models/GuildConfig.js
@@ -223,8 +223,17 @@ class GuildConfig {
             this[key] = guildConfig[key];
         }
         this.updatedAt = new Date();
+        const update = {};
+        for (const [key, value] of Object.entries(this) ) {
+            try {
+                JSON.stringify(value);
+                update[key] = value;
+            } catch (e) {
+                // There is nothing we can do here
+            }
+        }
 
-        const newConf = await this._axon.DBProvider.saveGuild(this.guildID, this);
+        const newConf = await this._axon.DBProvider.saveGuild(this.guildID, update);
         return newConf ? this : null;
     }
 


### PR DESCRIPTION
# PULL REQUEST

## **Overview**

PR addresses an issue when trying to save guild data that cannot be parsed into JSON, specifically circular objects.
Trying to save the database with MongoDB would result in a memory problem and cause Node to crashing or take as much memory as it could.

## **Status**

- [ ] Typings have been updated or don't need to be.
- [X] This PR have been tested and is ready to be merged.

## **Semantic versioning classification**

- [ ] MAJOR: This PR introduces *BREAKING* changes (direct API change).
- [ ] MINOR: This PR adds new features, improve the code and/or implies minimal API changes.
- [X] PATCH: This PR fixes a bug, if needed it also references the relevant issue or documentation.
- [ ] PATCH: This PR improve performance or code refactor without API changes.
- [ ] PATCH: This PR **only** includes non-code changes (documentation, style, CI, tools...).
